### PR TITLE
Add preview mode to the feedback editor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,9 @@ gem "omniauth-github"
 # Authorization framework
 gem "cancancan"
 
+# Epic Editor for markdown previewing
+gem "epic-editor-rails"
+
 group :production do
   gem 'pg'
   gem 'rails_12factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
     dotenv-rails (2.1.0)
       dotenv (= 2.1.0)
       railties (>= 4.0, < 5.1)
+    epic-editor-rails (0.2.4)
+      railties (>= 3.2, < 5.0)
     erubis (2.7.0)
     execjs (2.6.0)
     faraday (0.9.2)
@@ -203,6 +205,7 @@ DEPENDENCIES
   cancancan
   coffee-rails (~> 4.1.0)
   dotenv-rails
+  epic-editor-rails
   font-awesome-sass (~> 4.5.0)
   httparty
   jbuilder (~> 2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,4 +17,5 @@
 //= require dataTables.bootstrap
 //= require turbolinks
 //= require bootstrap-sprockets
+//= require epiceditor
 //= require_tree .

--- a/app/assets/javascripts/feedback.coffee
+++ b/app/assets/javascripts/feedback.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/feedback.js.erb
+++ b/app/assets/javascripts/feedback.js.erb
@@ -1,0 +1,13 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.
+
+$(document).ready(function() {
+  new EpicEditor({
+    theme: {
+      editor: '<%= asset_path 'editor/epic-light.css' %>'
+    },
+    autogrow: {
+      minHeight: 500
+    }
+  }).load();
+});

--- a/app/assets/javascripts/feedback.js.erb
+++ b/app/assets/javascripts/feedback.js.erb
@@ -3,6 +3,7 @@
 
 $(document).ready(function() {
   new EpicEditor({
+    clientSideStorage: false,
     theme: {
       editor: '<%= asset_path 'editor/epic-light.css' %>'
     },

--- a/app/assets/stylesheets/feedback.scss
+++ b/app/assets/stylesheets/feedback.scss
@@ -1,3 +1,8 @@
 // Place all the styles related to the feedback controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+#epiceditor {
+  border-style: solid;
+  border-width: 1px;
+}

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -5,7 +5,9 @@
     <%= link_to @repo.repo_url, @submission.pr_url, :target => "blank" %>
   </legend>
   <div class="control-group">
-    <%= text_area_tag "Feedback", @feedback_template, size: "100x15" %>
+    <div id="epiceditor">
+      <%= text_area_tag "Feedback", @feedback_template, size: "100x15" %>
+    </div>
   </div>
 </fieldset>
 <div class="control-group">


### PR DESCRIPTION
This uses Epic Editor: https://github.com/OscarGodson/EpicEditor

I've turned off their client-side storage because it runs into a complex set of problems I don't have time to solve right now. See 	commit 1e96883 for details.

Testing done: commented out most of `FeedbackController#create`, submitted some feedback and checked the logs. Text from the editor did appear in the POST request as expected.

This will resolve #34 