### PR TITLE
Upgrade debugging tools

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,11 +51,9 @@ group :development, :test do
   gem 'sqlite3'
 
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug'
+  gem 'pry-byebug'
+  gem 'pry-rescue'
 
-  gem 'pry'
-
-  gem 'binding_of_caller'
   gem 'better_errors'
 
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
     builder (3.2.2)
-    byebug (8.2.0)
+    byebug (9.0.6)
     cancancan (1.15.0)
     coderay (1.1.0)
     coffee-rails (4.1.0)
@@ -80,6 +80,7 @@ GEM
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
+    interception (0.5)
     jbuilder (2.3.2)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
@@ -121,10 +122,16 @@ GEM
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     pg (0.18.4)
-    pry (0.10.1)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.4.2)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    pry-rescue (1.4.5)
+      interception (>= 0.5)
+      pry
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -199,9 +206,7 @@ PLATFORMS
 
 DEPENDENCIES
   better_errors
-  binding_of_caller
   bootstrap-sass (~> 3.3.6)
-  byebug
   cancancan
   dotenv-rails
   epic-editor-rails
@@ -213,7 +218,8 @@ DEPENDENCIES
   omniauth
   omniauth-github
   pg
-  pry
+  pry-byebug
+  pry-rescue
   rails (= 4.2.4)
   rails_12factor
   sass-rails (~> 5.0)
@@ -225,4 +231,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.14.4
+   1.14.6


### PR DESCRIPTION
• Swap out pry and byebug for pry-byebug which gives all of the capabilities of byebug (step-by-step and stack navigation) inside of the pry CLI.

• Add pry-rescue which can trigger pry automatically on any unhandled exception (or test failure when combined with minitest).

• Remove explicit dependency on binding_of_caller because it's already included by other dependencies which we use more explicitly.