### PR TITLE
Authorization part 2: Invitation system

### DIFF
--- a/app/assets/javascripts/user_invites.js
+++ b/app/assets/javascripts/user_invites.js
@@ -1,0 +1,10 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.
+
+$(document).ready(function() {
+  // Make table of students sortable
+  $('#invites-table').DataTable({
+    paging: false,
+    "order": [[1, "asc"], [ 4, "desc" ], [ 2, "asc" ], [ 0, "asc" ]]
+  });
+});

--- a/app/assets/stylesheets/user_invites.scss
+++ b/app/assets/stylesheets/user_invites.scss
@@ -1,0 +1,3 @@
+.invite-btns {
+  margin-bottom: 2em;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,4 +15,8 @@ class ApplicationController < ActionController::Base
       redirect_to root_path
     end
   end
+
+  def not_found
+    { file: Rails.root.join('public', '404.html'), status: 404 }
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,6 +9,18 @@ class SessionsController < ApplicationController
       if @user
         session[:user_id] = @user.id
         session[:token] = auth_hash['credentials'].token
+
+        # If they've been invited, accept it automatically
+        github_name = auth_hash["extra"]["raw_info"]["login"]
+        invite = UserInvite.acceptable.find_by(github_name: github_name)
+        if invite
+          begin
+            @user.accept_invite(invite)
+          rescue
+            return redirect_to root_path, notice: "Unable to accept invitation"
+          end
+        end
+
         redirect_to pull_requests_path
       else
         redirect_to root_path, notice: "Failed to save the user"

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,7 +4,7 @@ class SessionsController < ApplicationController
   def create
     auth_hash = request.env['omniauth.auth']
 
-    if auth_hash["uid"]
+    if auth_hash && auth_hash["uid"]
       @user = User.find_or_create_from_omniauth(auth_hash)
       if @user
         session[:user_id] = @user.id

--- a/app/controllers/user_invites_controller.rb
+++ b/app/controllers/user_invites_controller.rb
@@ -3,14 +3,8 @@ class UserInvitesController < ApplicationController
     @invites = UserInvite.acceptable
   end
 
-  def new
-    role = params[:role]
-    return unless role.present?
-
-    render "new_#{role}"
-  rescue ActionView::MissingTemplate
-    render not_found
-  end
+  def new_student; end
+  def new_instructor; end
 
   def create
     action = :"create_#{params[:role]}"

--- a/app/controllers/user_invites_controller.rb
+++ b/app/controllers/user_invites_controller.rb
@@ -49,4 +49,20 @@ class UserInvitesController < ApplicationController
       alert:  msgs.reject(&:first).map(&:second),
     }
   end
+
+  def create_instructor
+    name = params[:github_name]
+    invite = UserInvite.create({
+      inviter: current_user,
+      github_name: name,
+      role: 'instructor'
+    })
+
+    if invite.persisted?
+      redirect_to user_invites_path, notice: "Successfully invited Github account #{name}"
+    else
+     flash[:alert] = "Could not invite #{name} because #{invite.errors.full_messages.first}"
+     render "new_instructor"
+    end
+  end
 end

--- a/app/controllers/user_invites_controller.rb
+++ b/app/controllers/user_invites_controller.rb
@@ -1,0 +1,5 @@
+class UserInvitesController < ApplicationController
+  def index
+    @invites = UserInvite.acceptable
+  end
+end

--- a/app/controllers/user_invites_controller.rb
+++ b/app/controllers/user_invites_controller.rb
@@ -11,4 +11,36 @@ class UserInvitesController < ApplicationController
   rescue ActionView::MissingTemplate
     render not_found
   end
+
+  def create
+    action = :"create_#{params[:role]}"
+    return send(action) if respond_to?(action, true)
+
+    render not_found
+  end
+
+  private
+
+  def create_student
+    github_names = params[:github_names].split(/[ \t\r\n]+/).map(&:strip)
+
+    msgs = github_names.map do |name|
+      invite = UserInvite.create({
+        inviter: current_user,
+        github_name: name,
+        role: 'student',
+      })
+
+      if invite.persisted?
+        [true, "Invited #{name}"]
+      else
+        [false, "Could not invite #{name} because #{invite.errors.full_messages.first}"]
+      end
+    end
+
+    redirect_to user_invites_path, {
+      notice: msgs.select(&:first).map(&:second),
+      alert:  msgs.reject(&:first).map(&:second),
+    }
+  end
 end

--- a/app/controllers/user_invites_controller.rb
+++ b/app/controllers/user_invites_controller.rb
@@ -2,4 +2,13 @@ class UserInvitesController < ApplicationController
   def index
     @invites = UserInvite.acceptable
   end
+
+  def new
+    role = params[:role]
+    return unless role.present?
+
+    render "new_#{role}"
+  rescue ActionView::MissingTemplate
+    render not_found
+  end
 end

--- a/app/controllers/user_invites_controller.rb
+++ b/app/controllers/user_invites_controller.rb
@@ -22,7 +22,7 @@ class UserInvitesController < ApplicationController
   private
 
   def create_student
-    github_names = params[:github_names].split(/[ \t\r\n]+/).map(&:strip)
+    github_names = params[:github_names].split(/[ \t\r\n]+/).map(&:strip).uniq
     cohort = Cohort.find_by(id: params[:cohort_id])
     if !cohort.present?
       return redirect_to user_invites_path,

--- a/app/controllers/user_invites_controller.rb
+++ b/app/controllers/user_invites_controller.rb
@@ -23,12 +23,18 @@ class UserInvitesController < ApplicationController
 
   def create_student
     github_names = params[:github_names].split(/[ \t\r\n]+/).map(&:strip)
+    cohort = Cohort.find_by(id: params[:cohort_id])
+    if !cohort.present?
+      return redirect_to user_invites_path,
+                         alert: "Could not find cohort with ID #{params[:cohort_id]}"
+    end
 
     msgs = github_names.map do |name|
       invite = UserInvite.create({
         inviter: current_user,
         github_name: name,
         role: 'student',
+        cohort: cohort
       })
 
       if invite.persisted?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,8 @@ module ApplicationHelper
   def github_link(path)
     "https://github.com/#{path}"
   end
+
+  def flash_messages(type)
+    simple_format(Array(flash[type]).join("\n"))
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def github_link(path)
+    "https://github.com/#{path}"
+  end
 end

--- a/app/models/user_invite.rb
+++ b/app/models/user_invite.rb
@@ -1,5 +1,6 @@
 class UserInvite < ActiveRecord::Base
   belongs_to :inviter, class_name: 'User'
+  belongs_to :cohort, dependent: :destroy
 
   validates_with UserRoleValidator
   validates :inviter, presence: true

--- a/app/models/user_invite.rb
+++ b/app/models/user_invite.rb
@@ -6,6 +6,8 @@ class UserInvite < ActiveRecord::Base
   validate :inviter_must_be_instructor
   validates :github_name, presence: true, uniqueness: true
 
+  scope :acceptable, -> { where(accepted: false) }
+
   private
 
   # Validations

--- a/app/models/user_invite.rb
+++ b/app/models/user_invite.rb
@@ -6,8 +6,13 @@ class UserInvite < ActiveRecord::Base
   validates :inviter, presence: true
   validate :inviter_must_be_instructor
   validates :github_name, presence: true, uniqueness: true
+  validate :only_students_have_cohort
 
   scope :acceptable, -> { where(accepted: false) }
+
+  def cohort?
+    cohort.present?
+  end
 
   private
 
@@ -15,6 +20,14 @@ class UserInvite < ActiveRecord::Base
   def inviter_must_be_instructor
     if inviter && inviter.role != 'instructor'
       errors.add(:inviter, "must be an instructor")
+    end
+  end
+
+  def only_students_have_cohort
+    if role == 'student'
+      errors.add(:cohort, "must be set for student invitations") unless cohort?
+    else
+      errors.add(:cohort, "may only be set for student invitations") if cohort?
     end
   end
 end

--- a/app/models/user_invite.rb
+++ b/app/models/user_invite.rb
@@ -10,6 +10,8 @@ class UserInvite < ActiveRecord::Base
 
   scope :acceptable, -> { where(accepted: false) }
 
+  default_scope { order(created_at: :desc) }
+
   def cohort?
     cohort.present?
   end

--- a/app/views/application/_errors.html.erb
+++ b/app/views/application/_errors.html.erb
@@ -1,12 +1,17 @@
 <% if flash.keys.length > 0 %>
   <% if flash[:error] %>
     <div class="bg-danger">
-      <%= flash[:error] %>
+      <%= flash_messages(:error) %>
+    </div>
+  <% end %>
+  <% if flash[:alert] %>
+    <div class="bg-danger">
+      <%= flash_messages(:alert) %>
     </div>
   <% end %>
   <% if flash[:notice] %>
     <div class="bg-success">
-      <%= flash[:notice] %>
+      <%= flash_messages(:notice) %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
           <li class= <%= 'active' if current_page?(pull_requests_path) %>><%= link_to "Home", root_path %></li>
           <li class= <%= 'active' if current_page?(repos_path) %>><%= link_to "Repos", repos_path %></li>
           <li class= <%= 'active' if current_page?(students_path) %>><%= link_to "Students", students_path %></li>
+          <li class= <%= 'active' if current_page?(user_invites_path) %>><%= link_to "Invites", user_invites_path %></li>
           <li><a href="#"></a></li>
           <li><%= link_to "Log In", "/auth/github" unless current_user %></li>
           <li><%= link_to "Log Out", logout_path, method: :delete if current_user %></li>

--- a/app/views/user_invites/index.html.erb
+++ b/app/views/user_invites/index.html.erb
@@ -2,7 +2,7 @@
   <%= link_to "Invite students", new_student_user_invites_path, class: "btn btn-large btn-success" %>
 </div>
 
-<table class="table">
+<table class="table" id="invites-table">
   <thead>
     <tr>
       <th>Invited GitHub Account</th>
@@ -18,7 +18,7 @@
       <td><%= i.role.humanize %></th>
       <td><%= i.cohort.display_name if i.cohort %></th>
       <td><%= i.inviter.name %></td>
-      <td><%= i.created_at.to_formatted_s(:long) %></td>
+      <td><%= i.created_at.strftime("%Y-%m-%d") %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/user_invites/index.html.erb
+++ b/app/views/user_invites/index.html.erb
@@ -1,3 +1,7 @@
+<div class="invite-btns">
+  <%= link_to "Invite students", new_student_user_invites_path, class: "btn btn-large btn-success" %>
+</div>
+
 <table class="table">
   <thead>
     <tr>

--- a/app/views/user_invites/index.html.erb
+++ b/app/views/user_invites/index.html.erb
@@ -7,6 +7,7 @@
     <tr>
       <th>Invited GitHub Account</th>
       <th>Role</th>
+      <th>Cohort</th>
       <th>Inviter</th>
       <th>Invitation Date</th>
     </tr>
@@ -15,6 +16,7 @@
     <tr>
       <td><%= link_to i.github_name, github_link(i.github_name), target: "_blank" %></td>
       <td><%= i.role.humanize %></th>
+      <td><%= i.cohort.display_name if i.cohort %></th>
       <td><%= i.inviter.name %></td>
       <td><%= i.created_at.to_formatted_s(:long) %></td>
     </tr>

--- a/app/views/user_invites/index.html.erb
+++ b/app/views/user_invites/index.html.erb
@@ -1,5 +1,6 @@
 <div class="invite-btns">
   <%= link_to "Invite students", new_student_user_invites_path, class: "btn btn-large btn-success" %>
+  <%= link_to "Invite instructor", new_instructor_user_invites_path, class: "btn btn-large btn-success" %>
 </div>
 
 <table class="table" id="invites-table">

--- a/app/views/user_invites/index.html.erb
+++ b/app/views/user_invites/index.html.erb
@@ -1,0 +1,18 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th>Invited GitHub Account</th>
+      <th>Role</th>
+      <th>Inviter</th>
+      <th>Invitation Date</th>
+    </tr>
+  </thead>
+  <% @invites.each do |i| %>
+    <tr>
+      <td><%= link_to i.github_name, github_link(i.github_name), target: "_blank" %></td>
+      <td><%= i.role.humanize %></th>
+      <td><%= i.inviter.name %></td>
+      <td><%= i.created_at.to_formatted_s(:long) %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/user_invites/new.html.erb
+++ b/app/views/user_invites/new.html.erb
@@ -1,2 +1,5 @@
 <h1>Invite a new user</h1>
 <h2>What kind of user would you like to invite?</h2>
+<div class="role-select">
+  <a class="btn btn-large btn-success" href="<%= new_student_user_invites_path %>">Student</a>
+</div>

--- a/app/views/user_invites/new.html.erb
+++ b/app/views/user_invites/new.html.erb
@@ -2,4 +2,5 @@
 <h2>What kind of user would you like to invite?</h2>
 <div class="role-select">
   <a class="btn btn-large btn-success" href="<%= new_student_user_invites_path %>">Student</a>
+  <a class="btn btn-large btn-success" href="<%= new_instructor_user_invites_path %>">Instructor</a>
 </div>

--- a/app/views/user_invites/new.html.erb
+++ b/app/views/user_invites/new.html.erb
@@ -1,6 +1,0 @@
-<h1>Invite a new user</h1>
-<h2>What kind of user would you like to invite?</h2>
-<div class="role-select">
-  <a class="btn btn-large btn-success" href="<%= new_student_user_invites_path %>">Student</a>
-  <a class="btn btn-large btn-success" href="<%= new_instructor_user_invites_path %>">Instructor</a>
-</div>

--- a/app/views/user_invites/new.html.erb
+++ b/app/views/user_invites/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Invite a new user</h1>
+<h2>What kind of user would you like to invite?</h2>

--- a/app/views/user_invites/new_instructor.html.erb
+++ b/app/views/user_invites/new_instructor.html.erb
@@ -1,0 +1,11 @@
+<h1>Invite New Instructor</h1>
+<%= form_tag user_invites_path do -%>
+  <%= hidden_field_tag 'role', 'instructor' %>
+
+  <div class="control-group">
+    <%= label_tag :github_name, 'Github name', class: 'control-label' %>
+    <%= text_field_tag :github_name, nil, class: 'form-control' %>
+  </div>
+
+  <%= submit_tag 'Invite', class: 'btn btn-primary' %>
+<% end -%>

--- a/app/views/user_invites/new_student.html.erb
+++ b/app/views/user_invites/new_student.html.erb
@@ -2,6 +2,12 @@
 <%= form_tag user_invites_path do -%>
   <%= hidden_field_tag 'role', 'student' %>
 
+  <div class="control-group">
+    <%= label_tag :cohort_id, 'Cohort', class: 'control-label' %>
+    <%= select_tag :cohort_id, options_from_collection_for_select(Cohort.all, :id, :display_name),
+                               class: 'form-control' %>
+  </div>
+
   <fieldset class="form-group">
     <%= label_tag do -%>
       <h3>GitHub Account Names</h3>

--- a/app/views/user_invites/new_student.html.erb
+++ b/app/views/user_invites/new_student.html.erb
@@ -1,0 +1,14 @@
+<h1>Invite New Students</h1>
+<%= form_tag user_invites_path do -%>
+  <%= hidden_field_tag 'role', 'student' %>
+
+  <fieldset class="form-group">
+    <%= label_tag do -%>
+      <h3>GitHub Account Names</h3>
+      <small id="github-names-help" class="form-text text-muted">Enter one GitHub account name per line</small>
+      <%= text_area_tag 'github_names', nil, size: '30x10', escape: false, class: 'form-control' %>
+    <% end -%>
+  </fieldset>
+
+  <%= submit_tag 'Invite', class: 'btn btn-primary' %>
+<% end -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,11 @@ Rails.application.routes.draw do
   end
   resources :students
   resources :pull_requests
-  resources :user_invites, only: [:index, :new]
+  resources :user_invites, only: [:index, :new] do
+    collection do
+      get "/new/student", action: :new, as: "new_student", role: "student"
+    end
+  end
 
   get "/auth/:provider/callback", to: "sessions#create"
   delete "/logout", to: "sessions#destroy"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   end
   resources :students
   resources :pull_requests
-  resources :user_invites, only: [:index]
+  resources :user_invites, only: [:index, :new]
 
   get "/auth/:provider/callback", to: "sessions#create"
   delete "/logout", to: "sessions#destroy"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   end
   resources :students
   resources :pull_requests
+  resources :user_invites, only: [:index]
 
   get "/auth/:provider/callback", to: "sessions#create"
   delete "/logout", to: "sessions#destroy"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   end
   resources :students
   resources :pull_requests
-  resources :user_invites, only: [:index, :new] do
+  resources :user_invites, only: [:index, :new, :create] do
     collection do
       get "/new/student", action: :new, as: "new_student", role: "student"
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,9 @@ Rails.application.routes.draw do
   resources :pull_requests
   resources :user_invites, only: [:index, :new, :create] do
     collection do
-      get "/new/student", action: :new, as: "new_student", role: "student"
+      %w(student instructor).each do |role|
+        get "/new/#{role}", action: :new, as: "new_#{role}", role: role
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,10 +10,10 @@ Rails.application.routes.draw do
   end
   resources :students
   resources :pull_requests
-  resources :user_invites, only: [:index, :new, :create] do
+  resources :user_invites, only: [:index, :create] do
     collection do
       %w(student instructor).each do |role|
-        get "/new/#{role}", action: :new, as: "new_#{role}", role: role
+        get "/new/#{role}", action: "new_#{role}", as: "new_#{role}"
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   end
   resources :students
   resources :pull_requests
-  resources :user_invites, only: [:index, :create] do
+  resources :user_invites, only: [:index, :create], path: 'invites' do
     collection do
       %w(student instructor).each do |role|
         get "/new/#{role}", action: "new_#{role}", as: "new_#{role}"

--- a/db/migrate/20170331232617_add_cohort_to_user_invites.rb
+++ b/db/migrate/20170331232617_add_cohort_to_user_invites.rb
@@ -1,0 +1,5 @@
+class AddCohortToUserInvites < ActiveRecord::Migration
+  def change
+    add_reference :user_invites, :cohort, foreign_key: { on_delete: :cascade }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170216220512) do
+ActiveRecord::Schema.define(version: 20170331232617) do
 
   create_table "cohorts", force: :cascade do |t|
     t.integer  "number",            null: false
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 20170216220512) do
     t.boolean  "accepted",    default: false,     null: false
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
+    t.integer  "cohort_id"
   end
 
   add_index "user_invites", ["github_name"], name: "index_user_invites_on_github_name", unique: true

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,7 +1,39 @@
 require 'test_helper'
 
 class SessionsControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
+  class Create < SessionsControllerTest
+    setup do
+      request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:github].dup
+    end
+
+    test 'with no OAuth data redirects to root' do
+      request.env['omniauth.auth'] = nil
+
+      get :create, provider: :github
+
+      assert_response :redirect
+      assert_redirected_to root_path
+      refute_nil flash[:notice]
+    end
+
+    test 'OAuth login redirects to pull requests page' do
+      get :create, provider: :github
+
+      assert_response :redirect
+      assert_redirected_to pull_requests_path
+      assert_nil flash[:notice]
+    end
+
+    test 'first-time OAuth login creates a new user' do
+      assert_difference(lambda{ User.count }, 1) do
+        get :create, provider: :github
+      end
+
+      # Additional logins do not create new users
+      assert_no_difference(lambda{ User.count }) do
+        get :create, provider: :github
+      end
+    end
+  end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -73,16 +73,14 @@ class SessionsControllerTest < ActionController::TestCase
       # sanity check
       assert_equal 'unknown', user.role
 
-      UserInvite.create({
-        github_name: 'adatest',
-        role: 'student',
-        inviter: User.where(role: 'instructor').first
-      })
+      # Create a new invite by copying from an existing
+      # valid invite and making it work for this user
+      user_invites(:valid_instructor).dup.update(github_name: 'adatest')
 
       get :create, provider: :github
 
       user.reload
-      assert_equal 'student', user.role
+      assert_equal user_invites(:valid_instructor).role, user.role
     end
   end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -3,8 +3,12 @@ require 'test_helper'
 class SessionsControllerTest < ActionController::TestCase
 
   class Create < SessionsControllerTest
+    def set_auth_mock(provider)
+      request.env['omniauth.auth'] = OmniAuth.config.mock_auth[provider].dup
+    end
+
     setup do
-      request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:github].dup
+      set_auth_mock :github
     end
 
     test 'with no OAuth data redirects to root' do

--- a/test/controllers/user_invites_controller_test.rb
+++ b/test/controllers/user_invites_controller_test.rb
@@ -3,7 +3,8 @@ require 'test_helper'
 class UserInvitesControllerTest < ActionController::TestCase
   class Unauthenticated < UserInvitesControllerTest
     ACTIONS = {
-      index: :get
+      index: :get,
+      new: :get
     }
 
     ACTIONS.each do |action, method|
@@ -32,6 +33,20 @@ class UserInvitesControllerTest < ActionController::TestCase
         get :index
 
         assert_template 'index'
+      end
+    end
+
+    class New < Authenticated
+      test 'responds with success' do
+        get :new
+
+        assert_response :ok
+      end
+
+      test 'renders appropriate template' do
+        get :new
+
+        assert_template 'new'
       end
     end
   end

--- a/test/controllers/user_invites_controller_test.rb
+++ b/test/controllers/user_invites_controller_test.rb
@@ -44,9 +44,21 @@ class UserInvitesControllerTest < ActionController::TestCase
       end
 
       test 'renders appropriate template' do
+        # Initial page with options for student/instructor
         get :new
 
         assert_template 'new'
+
+        # Student form
+        get :new, role: 'student'
+
+        assert_template 'new_student'
+      end
+
+      test 'responds 404 with invalid role' do
+        get :new, role: 'unknown'
+
+        assert_response :not_found
       end
     end
   end

--- a/test/controllers/user_invites_controller_test.rb
+++ b/test/controllers/user_invites_controller_test.rb
@@ -4,7 +4,8 @@ class UserInvitesControllerTest < ActionController::TestCase
   class Unauthenticated < UserInvitesControllerTest
     ACTIONS = {
       index: :get,
-      new: :get,
+      new_student: :get,
+      new_instructor: :get,
       create: :get
     }
 
@@ -37,34 +38,31 @@ class UserInvitesControllerTest < ActionController::TestCase
       end
     end
 
-    class New < Authenticated
+    class NewStudent < Authenticated
       test 'responds with success' do
-        get :new
+        get :new_student
 
         assert_response :ok
       end
 
       test 'renders appropriate template' do
-        # Initial page with options for student/instructor
-        get :new
-
-        assert_template 'new'
-
-        # Student form
-        get :new, role: 'student'
+        get :new_student
 
         assert_template 'new_student'
+      end
+    end
 
-        # Instructor form
-        get :new, role: 'instructor'
+    class NewInstructor < Authenticated
+      test 'responds with success' do
+        get :new_instructor
 
-        assert_template 'new_instructor'
+        assert_response :ok
       end
 
-      test 'responds 404 with invalid role' do
-        get :new, role: 'unknown'
+      test 'renders appropriate template' do
+        get :new_instructor
 
-        assert_response :not_found
+        assert_template 'new_instructor'
       end
     end
 

--- a/test/controllers/user_invites_controller_test.rb
+++ b/test/controllers/user_invites_controller_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class UserInvitesControllerTest < ActionController::TestCase
+  class Unauthenticated < UserInvitesControllerTest
+    ACTIONS = {
+      index: :get
+    }
+
+    ACTIONS.each do |action, method|
+      test "#{action} responds with redirect to root" do
+        send(method, action)
+
+        assert_response :redirect
+        assert_redirected_to root_path
+      end
+    end
+  end
+
+  class Authenticated < UserInvitesControllerTest
+    setup do
+      session[:user_id] = users(:instructor).id
+    end
+
+    class Index < Authenticated
+      test 'responds with success' do
+        get :index
+
+        assert_response :ok
+      end
+
+      test 'renders appropriate template' do
+        get :index
+
+        assert_template 'index'
+      end
+    end
+  end
+end

--- a/test/controllers/user_invites_controller_test.rb
+++ b/test/controllers/user_invites_controller_test.rb
@@ -123,6 +123,14 @@ class UserInvitesControllerTest < ActionController::TestCase
             refute_nil flash[:alert]
           end
         end
+
+        test 'ignores duplicate names' do
+          assert_difference(lambda{ UserInvite.count }, github_names.length) do
+            post :create, create_params.merge({
+              github_names: (github_names + [github_names.last]).join("\n")
+            })
+          end
+        end
       end
     end
   end

--- a/test/controllers/user_invites_controller_test.rb
+++ b/test/controllers/user_invites_controller_test.rb
@@ -54,6 +54,11 @@ class UserInvitesControllerTest < ActionController::TestCase
         get :new, role: 'student'
 
         assert_template 'new_student'
+
+        # Instructor form
+        get :new, role: 'instructor'
+
+        assert_template 'new_instructor'
       end
 
       test 'responds 404 with invalid role' do

--- a/test/controllers/user_invites_controller_test.rb
+++ b/test/controllers/user_invites_controller_test.rb
@@ -105,11 +105,7 @@ class UserInvitesControllerTest < ActionController::TestCase
         end
 
         test 'does not create duplicate invites' do
-          UserInvite.create!({
-            inviter: users(:instructor),
-            role: 'student',
-            github_name: 'adatest1'
-          })
+          user_invites(:valid_student).dup.update(github_name: 'adatest1')
 
           assert_difference(lambda{ UserInvite.count }, github_names.length - 1) do
             post :create, create_params

--- a/test/controllers/user_invites_controller_test.rb
+++ b/test/controllers/user_invites_controller_test.rb
@@ -80,7 +80,8 @@ class UserInvitesControllerTest < ActionController::TestCase
         def create_params
           {
             role: 'student',
-            github_names: github_names.join("\n")
+            github_names: github_names.join("\n"),
+            cohort_id: cohorts(:sharks)
           }
         end
 
@@ -112,6 +113,14 @@ class UserInvitesControllerTest < ActionController::TestCase
 
             assert_equal github_names.length, (flash[:notice].length + flash[:alert].length)
               'Flash messages must have a number of entries that matches the number of GitHub names submitted'
+          end
+        end
+
+        test 'does not create invites for non-existent cohort' do
+          assert_difference(lambda{ UserInvite.count }, 0) do
+            post :create, create_params.merge(cohort_id: -1)
+
+            refute_nil flash[:alert]
           end
         end
       end

--- a/test/controllers/user_invites_controller_test.rb
+++ b/test/controllers/user_invites_controller_test.rb
@@ -110,6 +110,12 @@ class UserInvitesControllerTest < ActionController::TestCase
           end
         end
 
+        test 'creates invites with student role' do
+          assert_difference(lambda{ UserInvite.where(role: 'student').count }, github_names.length) do
+            post :create, create_params
+          end
+        end
+
         test 'does not create duplicate invites' do
           user_invites(:valid_student).dup.update(github_name: 'adatest1')
 
@@ -168,6 +174,12 @@ class UserInvitesControllerTest < ActionController::TestCase
 
         test 'creates a new invite' do
           assert_difference(lambda{ UserInvite.count }, 1) do
+            post :create, create_params
+          end
+        end
+
+        test 'creates invite with instructor role' do
+          assert_difference(lambda{ UserInvite.where(role: 'instructor').count }, 1) do
             post :create, create_params
           end
         end

--- a/test/fixtures/user_invites.yml
+++ b/test/fixtures/user_invites.yml
@@ -1,12 +1,18 @@
-instructor:
+valid_instructor:
   github_name: adainstructor
   role: instructor
   inviter: instructor
   accepted: false
 
-student:
+valid_student:
   github_name: adastudent
   role: student
+  inviter: instructor
+  accepted: false
+
+valid_unknown:
+  github_name: adaunknown
+  role: unknown
   inviter: instructor
   accepted: false
 

--- a/test/fixtures/user_invites.yml
+++ b/test/fixtures/user_invites.yml
@@ -2,7 +2,7 @@ instructor:
   github_name: adainstructor
   role: instructor
   inviter: instructor
-  accepted: true
+  accepted: false
 
 student:
   github_name: adastudent

--- a/test/fixtures/user_invites.yml
+++ b/test/fixtures/user_invites.yml
@@ -7,6 +7,7 @@ valid_instructor:
 valid_student:
   github_name: adastudent
   role: student
+  cohort: sharks
   inviter: instructor
   accepted: false
 

--- a/test/models/user_invite_test.rb
+++ b/test/models/user_invite_test.rb
@@ -58,5 +58,20 @@ class UserInviteTest < ActiveSupport::TestCase
       invalid_invite = UserInvite.new(valid_attrs)
       refute invalid_invite.valid?
     end
+
+    test 'validates cohort must be specified when role is student' do
+      valid_invite.cohort = nil
+      valid_invite.role = 'student'
+      refute valid_invite.valid?
+    end
+
+    test 'validates cohort must not be specified when role is not student' do
+      valid_invite.cohort = cohorts(:sharks)
+
+      (User::ROLES - ['student']).each do |role|
+        valid_invite.role = role
+        refute valid_invite.valid?
+      end
+    end
   end
 end

--- a/test/models/user_invite_test.rb
+++ b/test/models/user_invite_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class UserInviteTest < ActiveSupport::TestCase
   class Validations < UserInviteTest
     def valid_invite
-      user_invites(:instructor)
+      user_invites(:valid_instructor)
     end
 
     setup do
@@ -13,8 +13,10 @@ class UserInviteTest < ActiveSupport::TestCase
 
     test 'validates role is in predefined set' do
       User::ROLES.each do |role|
-        valid_invite.role = role
-        assert valid_invite.valid?
+        invite = user_invites(:"valid_#{role}")
+        refute_nil invite
+        assert_equal role, invite.role
+        assert invite.valid?
       end
 
       invalid_role = User::ROLES.sum

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -32,7 +32,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     test 'sets role based on invite' do
-      invite = user_invites(:student)
+      invite = user_invites(:valid_student)
       # sanity check
       refute_equal invite.role, invitee.role
 
@@ -42,7 +42,7 @@ class UserTest < ActiveSupport::TestCase
     end
 
     test 'marks invite as accepted' do
-      invite = user_invites(:student)
+      invite = user_invites(:valid_student)
       # sanity check
       refute invite.accepted?
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,7 +34,10 @@ class ActiveSupport::TestCase
   end
 
   AUTH_MOCKS = {
-    github: auth_mock('Test User', 'adatest')
+    github: auth_mock('Test User', 'adatest'),
+    uninvited: auth_mock('Uninvited User', 'adauninvited'),
+    invited_instructor: auth_mock('Invited Instructor', 'adainstructor'),
+    invited_student: auth_mock('Invited Student', 'adastudent')
   }
 
   AUTH_MOCKS.each do |provider, auth_hash|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,20 +11,33 @@ class ActiveSupport::TestCase
   # Use OmniAuth's mock responses
   OmniAuth.config.test_mode = true
 
-  OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
+  OmniAuth.config.mock_auth[:default] = OmniAuth::AuthHash.new({
     provider: 'github',
     uid: 123456,
-    info: {
-      name: 'Test User'
-    },
-    extra: {
-      raw_info: {
-        login: 'adatest'
-      }
-    },
-    credentials: {
-      token: '7ca3303893156b8c45185b61d0fc8ec3153ee33f',
-      expires: false
-    }
   })
+
+  def self.auth_mock(name, login)
+    {
+      info: {
+        name: name
+      },
+      extra: {
+        raw_info: {
+          login: login
+        }
+      },
+      credentials: {
+        token: '7ca3303893156b8c45185b61d0fc8ec3153ee33f',
+        expires: false
+      }
+    }
+  end
+
+  AUTH_MOCKS = {
+    github: auth_mock('Test User', 'adatest')
+  }
+
+  AUTH_MOCKS.each do |provider, auth_hash|
+    OmniAuth.config.send(:add_mock, provider, auth_hash)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,11 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
+# Uncomment these lines to automatically start pry
+# when a test fails or an exception is unhandled.
+#require 'minitest/autorun'
+#require 'pry-rescue/minitest'
+
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,4 +7,24 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+
+  # Use OmniAuth's mock responses
+  OmniAuth.config.test_mode = true
+
+  OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
+    provider: 'github',
+    uid: 123456,
+    info: {
+      name: 'Test User'
+    },
+    extra: {
+      raw_info: {
+        login: 'adatest'
+      }
+    },
+    credentials: {
+      token: '7ca3303893156b8c45185b61d0fc8ec3153ee33f',
+      expires: false
+    }
+  })
 end


### PR DESCRIPTION
Note: This branch is currently rebased ontop of the `Hamled/debugging` branch, so we should probably review and merge #43 first.

This PR adds an invitation system which can be used to selectively give roles for specific GitHub accounts.

The general flow is:
- [x] Instructors invite students and other instructors/staff using their GitHub user name
- [x] When people log in via OAuth we automatically create an account for them
- [x] If there's a pending invite for their github name, they automatically "accept" it and their account gets the role from their invite 
- [ ] The authorization framework will restrict access to different functionality / sections of the site based on role

Other things to note:
- Students can be invited in bulk
- Students must be invited to a specific cohort (this was intended for when I wanted to create `Student` models based on invites, but we need to discuss whether that is desirable or not)
- Anyone who logs in w/o an invite has the `unknown` role, which will be fully restricted when the authorization framework is implemented

This PR also adds tests for the session controller by using OmniAuth mocks.