### PR TITLE
Minor bug fixes uncovered during deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "epic-editor-rails"
 group :production do
   gem 'pg'
   gem 'rails_12factor'
+  gem 'rdoc', '~> 4.3'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
-    rdoc (4.2.0)
+    rdoc (4.3.0)
     sass (3.4.19)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -222,6 +222,7 @@ DEPENDENCIES
   pry-rescue
   rails (= 4.2.4)
   rails_12factor
+  rdoc (~> 4.3)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring
@@ -231,4 +232,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ActiveRecord::Base
       user = User.new
       user.uid = auth_hash["uid"]
       user.provider = auth_hash["provider"]
-      user.name = auth_hash["info"]["name"]
+      user.name = auth_hash["info"]["name"] || auth_hash["info"]["nickname"]
       # user.email = auth_hash["info"]["email"]
 
       if user.save


### PR DESCRIPTION
The first is some kind of issue that Heroku's systems have with installing the `rdoc` gem version 4.2.0. One fix that seems to work is forcing the version of `rdoc` to 4.3.

The second issue I noticed when testing the new invite system with a test account that I set up on GitHub. I didn't give it a name at first and was unable to log in as a result.

Now if someone logs in and has no name set on GitHub we default to using their login name. In the future we should do one or both of the following:
* Allow users to set a name for themselves within the app. This would allow them to use the name that they go by at Ada within the app while using a different name or pseudonym on GitHub.
* Automatically update the name and any other fields we copy from GitHub, when the user logs in.