### PR TITLE
Bugfixes for the authorization system

### DIFF
--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -6,7 +6,7 @@ class PullRequestsController < ApplicationController
   load_and_authorize_resource class: Repo, instance_name: :repo, except: [:home]
 
   def home
-    if current_user
+    if can? :read, Repo
       redirect_to pull_requests_path
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,7 +22,7 @@ class SessionsController < ApplicationController
           end
         end
 
-        redirect_to pull_requests_path
+        redirect_to root_path
       else
         redirect_to root_path, notice: "Failed to save the user"
       end

--- a/test/controllers/pull_requests_controller_test.rb
+++ b/test/controllers/pull_requests_controller_test.rb
@@ -2,6 +2,59 @@ require 'test_helper'
 
 class PullRequestsControllerTest < ActionController::TestCase
   class Functionality < PullRequestsControllerTest
+    class Home < Functionality
+      class Instructor < Home
+        setup do
+          session[:user_id] = users(:instructor).id
+        end
+
+        test "should redirect to pull requests index" do
+          get :home
+
+          assert_response :redirect
+          assert_redirected_to pull_requests_path
+        end
+      end
+
+      class Student < Home
+        setup do
+          session[:user_id] = users(:student).id
+        end
+
+        test "should display the home view" do
+          get :home
+
+          assert_response :success
+          assert_template :home
+        end
+      end
+
+      class Unauthorized < Home
+        setup do
+          session[:user_id] = users(:unknown).id
+        end
+
+        test "should display the home view" do
+          get :home
+
+          assert_response :success
+          assert_template :home
+        end
+      end
+
+      class Guest < Home
+        setup do
+          session[:user_id] = nil
+        end
+
+        test "should display the home view" do
+          get :home
+
+          assert_response :success
+          assert_template :home
+        end
+      end
+    end
   end
 
   class Authorization < PullRequestsControllerTest

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -21,11 +21,11 @@ class SessionsControllerTest < ActionController::TestCase
         refute_nil flash[:notice]
       end
 
-      test 'OAuth login redirects to pull requests page' do
+      test 'OAuth login redirects to root' do
         get :create, provider: :github
 
         assert_response :redirect
-        assert_redirected_to pull_requests_path
+        assert_redirected_to root_path
         assert_nil flash[:notice]
       end
 


### PR DESCRIPTION
Somehow I missed that when logging in as a non-instructor the browser was put into an infinite redirect loop. This has been corrected in two ways:

* Sessions controller redirects to root instead of pull requests index after successful login
* Root action (`PullRequestsController#home`) only redirects to pull requests index if user can actually view pull requests.