### PR TITLE
Allow multiple invites per user, only 1 acceptable

### DIFF
--- a/app/models/user_invite.rb
+++ b/app/models/user_invite.rb
@@ -5,7 +5,7 @@ class UserInvite < ActiveRecord::Base
   validates_with UserRoleValidator
   validates :inviter, presence: true
   validate :inviter_must_be_instructor
-  validates :github_name, presence: true, uniqueness: true
+  validates :github_name, presence: true, uniqueness: { conditions: -> { acceptable } }
   validate :only_students_have_cohort
 
   scope :acceptable, -> { where(accepted: false) }

--- a/db/migrate/20170901182734_use_partial_index_on_user_invites.rb
+++ b/db/migrate/20170901182734_use_partial_index_on_user_invites.rb
@@ -1,0 +1,6 @@
+class UsePartialIndexOnUserInvites < ActiveRecord::Migration
+  def change
+    remove_index :user_invites, column: :github_name
+    add_index :user_invites, :github_name, unique: true, where: 'accepted = false'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170331232617) do
+ActiveRecord::Schema.define(version: 20170901182734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,7 +75,7 @@ ActiveRecord::Schema.define(version: 20170331232617) do
     t.integer  "cohort_id"
   end
 
-  add_index "user_invites", ["github_name"], name: "index_user_invites_on_github_name", unique: true, using: :btree
+  add_index "user_invites", ["github_name"], name: "index_user_invites_on_github_name", unique: true, where: "(accepted = false)", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "name",                           null: false


### PR DESCRIPTION
Previously we only allowed a single invite per user ever, but that is too restrictive. We really only want to prevent multiple invites per user that are simultaneously acceptable.