### PR TITLE
CanCanCan correctly loads singleton Repo resources

### DIFF
--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -1,7 +1,7 @@
 require 'github'
 
 class ReposController < ApplicationController
-  load_and_authorize_resource
+  load_and_authorize_resource id_param: :repo_id
 
   def index
   end


### PR DESCRIPTION
The `load_and_authorize_resource` helper method from CanCanCan was
unable to detect that `ReposController#show` should be getting a single
Repo instance rather than the collection of all Repo instances because
it was looking for `params` to have an `:id` key.

In our case, because the `show` action has a nested `Cohort` resource
the route parameters are `:repo_id` and `:cohort_id`. We now specify to
`load_and_authorize_resource` that it should look for `:repo_id`.