### PR TITLE
Actually fix the ReposController authorization issues

### DIFF
--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -1,18 +1,15 @@
 require 'github'
 
 class ReposController < ApplicationController
-  load_and_authorize_resource id_param: :repo_id
+  load_and_authorize_resource except: [:show]
+
+  load_and_authorize_resource :repo, parent: true, only: [:show]
+  load_and_authorize_resource :cohort, parent: false, only: [:show]
 
   def index
   end
 
   def show
-    @cohort = Cohort.find_by_id(params[:cohort_id])
-    if !@cohort
-      flash[:error] = "Cohort not found"
-      redirect_to :back
-    end
-
     gh = GitHub.new(session[:token])
     @all_data = gh.retrieve_student_info(@repo, @cohort)
   end
@@ -49,7 +46,7 @@ class ReposController < ApplicationController
   private
 
   rescue_from ActiveRecord::RecordNotFound do |ex|
-    flash[:error] = "Repo not found."
+    flash[:error] = "Resource not found."
     redirect_to repos_path
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root 'pull_requests#home'
 
   resources :repos do
-    get "/cohort/:cohort_id", to: "repos#show", as: :cohort
+    resources :cohort, only: [:show], controller: 'repos'
 
     resources :students, only: [] do
       resources :feedback, only: [:new, :create]

--- a/test/controllers/repos_controller_test.rb
+++ b/test/controllers/repos_controller_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class ReposControllerTest < ActionController::TestCase
   setup do
     @repo = repos(:word_guess)
+    @cohort = cohorts(:sharks)
   end
 
   def create_params
@@ -72,7 +73,6 @@ class ReposControllerTest < ActionController::TestCase
       assert_redirected_to repos_path
     end
 
-
     test "should get the edit form" do
       get :edit, { id: @repo.id }
 
@@ -104,6 +104,24 @@ class ReposControllerTest < ActionController::TestCase
       delete :destroy, { id: @repo.id }
 
       assert_redirected_to repos_path
+    end
+
+    def with_github_mock(&block)
+      github_mock = Minitest::Mock.new
+      def github_mock.retrieve_student_info(repo, cohort)
+        Submission.where(repo: repo)
+      end
+
+      GitHub.stub :new, github_mock, &block
+    end
+
+    test "should get the show page for a particular repo and cohort" do
+      with_github_mock do
+        get :show, { repo_id: @repo.id, id: @cohort.id }
+
+        assert_response :success
+        assert_template :show
+      end
     end
   end
 

--- a/test/controllers/repos_controller_test.rb
+++ b/test/controllers/repos_controller_test.rb
@@ -123,6 +123,18 @@ class ReposControllerTest < ActionController::TestCase
         assert_template :show
       end
     end
+
+    test "should redirect when cohort ID is invalid" do
+      invalid_cohort_id = 0
+      # Sanity check
+      assert_nil Cohort.find_by(id: invalid_cohort_id)
+
+      get :show, { repo_id: @repo.id, id: invalid_cohort_id }
+
+      assert_response :redirect
+      assert_redirected_to repos_path
+      assert_not_empty flash[:error]
+    end
   end
 
   class Authorization < ReposControllerTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,10 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'minitest/autorun'
 
 # Uncomment these lines to automatically start pry
 # when a test fails or an exception is unhandled.
-#require 'minitest/autorun'
 #require 'pry-rescue/minitest'
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
The previous fix in PR #58 was insufficient, as I would have realized had I run our tests before merging it in. While it _did_ fix the `show` action, it broke all of the other "singleton" actions in that controller (`edit`, `update`, `destroy`).

This is the actual fix, which is a bit more involved. Basically the `show` action has to use its own logic for loading and authorizing the necessary resources because it's the only action that has a nested resource. Further complicating things is that the nested resource is not actually the one our controller is "about" (this is `ReposController` but the nested resource is `Cohort`).

There are now tests for the `show` action as well, which required mocking the GitHub API library we've built.

This PR also changes the routes configuration to use a more traditional route setup for the `show` action.