### PR TITLE
Cleanup DB seeding logic and data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,36 +1,25 @@
-# # Create users
-# staff = ["kariabancroft"]
-#
-# staff.each do |s|
-#   u = { name: "Kari", }
-#   User.create()
-# end
+# Create instructor
+User.create(name: "Test Instructor 1", provider: :github, uid: "30710012", role: "instructor")
 
 # Create cohorts
 cohorts = [
-  { number: 6, name: "Brackets", instructor_emails: "kari@adadevelopersacademy.org,dan@adadevelopersacademy.org" },
-  { number: 6, name: "Parens", instructor_emails: "kari@adadevelopersacademy.org" }
+  { number: 0, name: "Peanut Butter", instructor_emails: "charles+classroom-local-pb-instructor@adadev.org" },
+  { number: 0, name: "Jelly", instructor_emails: "charles+classroom-local-jelly-instructor@adadev.org" }
 ]
 
 cohorts.each do |c|
   Cohort.create(c)
 end
 
-students = []
-students = CSV.read(Rails.root.join('lib', 'seeds', 'students.csv')).each do |stud|
-  stud_hash = {}
-  stud_hash[:name] = stud[1].titleize
-  c = Cohort.where("name LIKE :prefix", prefix: "#{stud[0]}%")
-  stud_hash[:cohort_id] = c.first.id
-  stud_hash[:email] = stud[2].downcase
-  stud_hash[:github_name] = stud[3].downcase
-
-  Student.create(stud_hash)
-end
+# Create students
+Student.create(name: "Test Student 1", cohort: Cohort.first,
+               github_name: "ada-student-1", email: "charles+classroom-local-student-1@adadev.org")
+Student.create(name: "Test Student 2", cohort: Cohort.last,
+               github_name: "ada-student-2", email: "charles+classroom-local-student-2@adadev.org")
 
 repos = [
-  { repo_url: "Ada-C6/Scrabble", individual: false},
-  { repo_url: "Ada-C6/BankAccounts"}
+  { repo_url: "Ada-Test/PR-App-test-group", individual: false},
+  { repo_url: "Ada-Test/PR-App-test-individual"}
 ]
 
 repos.each do |repo|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,5 @@
 # Create instructor
-User.create(name: "Test Instructor 1", provider: :github, uid: "30710012", role: "instructor")
+User.create!(name: "Test Instructor 1", provider: :github, uid: "30710012", role: "instructor")
 
 # Create cohorts
 cohorts = [
@@ -8,13 +8,13 @@ cohorts = [
 ]
 
 cohorts.each do |c|
-  Cohort.create(c)
+  Cohort.create!(c)
 end
 
 # Create students
-Student.create(name: "Test Student 1", cohort: Cohort.first,
+Student.create!(name: "Test Student 1", cohort: Cohort.first,
                github_name: "ada-student-1", email: "charles+classroom-local-student-1@adadev.org")
-Student.create(name: "Test Student 2", cohort: Cohort.last,
+Student.create!(name: "Test Student 2", cohort: Cohort.last,
                github_name: "ada-student-2", email: "charles+classroom-local-student-2@adadev.org")
 
 repos = [
@@ -23,7 +23,7 @@ repos = [
 ]
 
 repos.each do |repo|
-  r = Repo.create(repo)
+  r = Repo.create!(repo)
   r.cohorts << Cohort.all
   r.save
 end


### PR DESCRIPTION
We now seed data that matches actual GitHub data (instructors, students, and repositories). We also no longer attempt to seed students from a CSV file, as that should be done manually and only for live production deployments.

Note: We seed a single user, tied to the GitHub account @ada-instructor-1. This is a real GitHub account and if you have the password then you can use it to log in and invite your personal GitHub account as an instructor.

If you do not have the password you will need to log in with your personal GitHub account, then open `rails console` and directly set your `User` record to have the `instructor` role.