### PR TITLE
Link User accounts to Student records

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
     auth_hash = request.env['omniauth.auth']
 
     if auth_hash && auth_hash["uid"]
-      @user = User.find_or_create_from_omniauth(auth_hash)
+      @user = User.update_or_create_from_omniauth(auth_hash)
       if @user
         session[:user_id] = @user.id
         session[:token] = auth_hash['credentials'].token

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -1,4 +1,5 @@
 class Student < ActiveRecord::Base
+  belongs_to :user, foreign_key: :github_name, primary_key: :github_name
   belongs_to :cohort
   has_many :submissions
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ActiveRecord::Base
-  validates :name, :uid, :provider, presence: true
+  validates :name, :uid, :provider, :github_name, presence: true
   validates_with UserRoleValidator
 
   ROLES = %w( instructor student unknown )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,8 @@ class User < ActiveRecord::Base
       user = User.new
       user.uid = auth_hash["uid"]
       user.provider = auth_hash["provider"]
-      user.name = auth_hash["info"]["name"] || auth_hash["info"]["nickname"]
+      user.github_name = auth_hash["extra"]["raw_info"]["login"]
+      user.name = auth_hash["info"]["name"] || auth_hash["extra"]["raw_info"]["login"]
       # user.email = auth_hash["info"]["email"]
 
       if user.save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,11 +4,11 @@ class User < ActiveRecord::Base
 
   ROLES = %w( instructor student unknown )
 
-  def self.find_or_create_from_omniauth(auth_hash)
+  def self.update_or_create_from_omniauth(auth_hash)
     gh_info = github_info(auth_hash)
     user = self.find_by(uid: gh_info[:uid], provider: gh_info[:provider])
     if !user.nil?
-      return user
+      return user if user.update(gh_info)
     else
       # no user found, do something here
       user = User.new(gh_info)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,17 +5,13 @@ class User < ActiveRecord::Base
   ROLES = %w( instructor student unknown )
 
   def self.find_or_create_from_omniauth(auth_hash)
-    user = self.find_by(uid: auth_hash["uid"], provider: auth_hash["provider"])
+    gh_info = github_info(auth_hash)
+    user = self.find_by(uid: gh_info[:uid], provider: gh_info[:provider])
     if !user.nil?
       return user
     else
       # no user found, do something here
-      user = User.new
-      user.uid = auth_hash["uid"]
-      user.provider = auth_hash["provider"]
-      user.github_name = auth_hash["extra"]["raw_info"]["login"]
-      user.name = auth_hash["info"]["name"] || auth_hash["extra"]["raw_info"]["login"]
-      # user.email = auth_hash["info"]["email"]
+      user = User.new(gh_info)
 
       if user.save
         return user
@@ -45,5 +41,16 @@ class User < ActiveRecord::Base
 
   def authorized?
     role != 'unknown'
+  end
+
+  private
+
+  def self.github_info(auth_hash)
+    {
+      uid: auth_hash["uid"],
+      provider: auth_hash["provider"],
+      github_name: auth_hash["extra"]["raw_info"]["login"],
+      name: auth_hash["info"]["name"] || auth_hash["extra"]["raw_info"]["login"]
+    }
   end
 end

--- a/db/migrate/20170911220716_add_github_name_to_users.rb
+++ b/db/migrate/20170911220716_add_github_name_to_users.rb
@@ -1,0 +1,6 @@
+class AddGithubNameToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :github_name, :text
+    add_index :users, :github_name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170901182734) do
+ActiveRecord::Schema.define(version: 20170911220716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,14 +78,16 @@ ActiveRecord::Schema.define(version: 20170901182734) do
   add_index "user_invites", ["github_name"], name: "index_user_invites_on_github_name", unique: true, where: "(accepted = false)", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "name",                           null: false
-    t.string   "uid",                            null: false
-    t.string   "provider",                       null: false
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
-    t.string   "role",       default: "unknown", null: false
+    t.string   "name",                            null: false
+    t.string   "uid",                             null: false
+    t.string   "provider",                        null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+    t.string   "role",        default: "unknown", null: false
+    t.text     "github_name"
   end
 
+  add_index "users", ["github_name"], name: "index_users_on_github_name", unique: true, using: :btree
   add_index "users", ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true, using: :btree
 
   add_foreign_key "submissions", "users"

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -40,6 +40,17 @@ class SessionsControllerTest < ActionController::TestCase
         end
       end
 
+      test 'first-time OAuth login sets appropriate fields on User record' do
+        get :create, provider: :github
+
+        user = User.last
+        auth_hash = request.env['omniauth.auth']
+        assert_equal user.uid, auth_hash['uid'].to_s
+        assert_equal user.provider, auth_hash['provider']
+        assert_equal user.github_name, auth_hash['extra']['raw_info']['login']
+        assert_equal user.name, auth_hash['info']['name']
+      end
+
       test 'uninvited users have unknown role' do
         set_auth_mock :uninvited
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -55,6 +55,28 @@ class SessionsControllerTest < ActionController::TestCase
         assert_equal user.name, auth_hash['info']['name']
       end
 
+      test 'existing users update info on login' do
+        # Simulate an account which was created before storing github_name
+        user = users(:unknown)
+        user.github_name = nil
+        user.save!(validate: false)
+
+        user_info = {
+          github_name: user.github_name,
+          name: user.name
+        }
+
+        set_auth_mock :github_changed_info
+        request.env['omniauth.auth']['uid'] = user.uid
+
+        get :create, provider: :github
+
+        user.reload
+        user_info.each do |attr, old_value|
+          assert_not_equal user.send(attr), old_value, "Expected User##{attr} to not be #{old_value.inspect}"
+        end
+      end
+
       test 'uninvited users have unknown role' do
         set_auth_mock :uninvited
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -4,7 +4,11 @@ class SessionsControllerTest < ActionController::TestCase
   class Functionality < SessionsControllerTest
     class Create < Functionality
       def set_auth_mock(provider)
-        request.env['omniauth.auth'] = OmniAuth.config.mock_auth[provider].dup
+        mock = OmniAuth.config.mock_auth[provider].dup
+        # This is necessary because OmniAuth only allows us to have one mock per provider
+        mock['provider'] = OmniAuth.config.mock_auth[:default]['provider']
+
+        request.env['omniauth.auth'] = mock
       end
 
       setup do

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -18,3 +18,10 @@ student:
   provider: github
   role: student
   github_name: ada-test-student-1
+
+student_shark:
+  name: Shark Student
+  uid: 12348
+  provider: github
+  role: student
+  github_name: ada-student-shark

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,15 +3,18 @@ unknown:
   uid: 12345
   provider: github
   role: unknown
+  github_name: adatest
 
 instructor:
   name: Instructor User
   uid: 12346
   provider: github
   role: instructor
+  github_name: adainstructor
 
 student:
   name: Student User
   uid: 12347
   provider: github
   role: student
+  github_name: adastudent

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,18 +3,18 @@ unknown:
   uid: 12345
   provider: github
   role: unknown
-  github_name: adatest
+  github_name: ada-test-unknown-1
 
 instructor:
   name: Instructor User
   uid: 12346
   provider: github
   role: instructor
-  github_name: adainstructor
+  github_name: ada-test-instructor-1
 
 student:
   name: Student User
   uid: 12347
   provider: github
   role: student
-  github_name: adastudent
+  github_name: ada-test-student-1

--- a/test/models/student_test.rb
+++ b/test/models/student_test.rb
@@ -1,7 +1,18 @@
 require 'test_helper'
 
 class StudentTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  class Associations < StudentTest
+    test 'can be associated with a User account' do
+      student = students(:shark)
+
+      assert_not_nil student.user
+      assert_equal student.user, users(:student_shark)
+    end
+
+    test 'can be unassociated with a User account' do
+      student = students(:jet)
+
+      assert_nil student.user
+    end
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -18,6 +18,11 @@ class UserTest < ActiveSupport::TestCase
       @valid_user.role = invalid_role
       refute @valid_user.valid?
     end
+
+    test 'validates presence of github_name' do
+      @valid_user.github_name = nil
+      refute @valid_user.valid?
+    end
   end
 
   class AcceptInvite < UserTest

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,19 +2,21 @@ require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   class Validations < UserTest
-    test 'validates role is in predefined set' do
-      valid_user = users(:unknown)
+    setup do
+      @valid_user = users(:unknown)
       # sanity check
-      assert valid_user.valid?
+      assert @valid_user.valid?
+    end
 
+    test 'validates role is in predefined set' do
       User::ROLES.each do |role|
-        valid_user.role = role
-        assert valid_user.valid?
+        @valid_user.role = role
+        assert @valid_user.valid?
       end
 
       invalid_role = User::ROLES.sum
-      valid_user.role = invalid_role
-      refute valid_user.valid?
+      @valid_user.role = invalid_role
+      refute @valid_user.valid?
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,7 +42,8 @@ class ActiveSupport::TestCase
     github: auth_mock('Test User', 'adatest'),
     uninvited: auth_mock('Uninvited User', 'adauninvited'),
     invited_instructor: auth_mock('Invited Instructor', 'adainstructor'),
-    invited_student: auth_mock('Invited Student', 'adastudent')
+    invited_student: auth_mock('Invited Student', 'adastudent'),
+    github_changed_info: auth_mock('Changed User', 'adachanged')
   }
 
   AUTH_MOCKS.each do |provider, auth_hash|


### PR DESCRIPTION
The only way that we can link these models is through GitHub user name, so we need to store that information on the `User` model use it to form the association.