### PR TITLE
Redirect students to appropriate page after login

### DIFF
--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -8,6 +8,11 @@ class PullRequestsController < ApplicationController
   def home
     if can? :read, Repo
       redirect_to pull_requests_path
+    elsif can? :read, Student
+      students = Student.accessible_by(current_ability)
+
+      redirect_to students.first if students.length == 1
+      redirect_to students_path if students.length > 1
     end
   end
 


### PR DESCRIPTION
Our logic right now gives priority to viewing Repos, however if the
currently logged in user cannot view Repos we fall back to checking if
they can view Students.

If there is only one Student object they can view, we redirect them to
the show page for that Student. If they can view more than one, we
redirect them to the index of all Students they can view. Otherwise, we
continue to display the standard home page.