### PR TITLE
Seeding instructor user works correctly

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,9 @@
 # Create instructor
-User.create!(name: "Test Instructor 1", provider: :github, uid: "30710012", role: "instructor")
+User.create!(name: "Test Instructor 1",
+             provider: :github,
+             uid: "30710012",
+             github_name: "ada-instructor-1",
+             role: "instructor")
 
 # Create cohorts
 cohorts = [


### PR DESCRIPTION
This was broken in 391d8e0 by adding a validation that all users must have a GitHub username.