### PR TITLE
Upgrade Spring version and fix binstubs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,8 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     slop (3.6.0)
-    spring (1.4.1)
+    spring (2.0.2)
+      activesupport (>= 4.2)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -242,4 +243,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.15.3
+   1.16.1

--- a/bin/rails
+++ b/bin/rails
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 begin
   load File.expand_path('../spring', __FILE__)
-rescue LoadError
+rescue LoadError => e
+  raise unless e.message.include?('spring')
 end
 APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'

--- a/bin/rake
+++ b/bin/rake
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 begin
   load File.expand_path('../spring', __FILE__)
-rescue LoadError
+rescue LoadError => e
+  raise unless e.message.include?('spring')
 end
 require_relative '../config/boot'
 require 'rake'

--- a/bin/spring
+++ b/bin/spring
@@ -7,9 +7,11 @@ unless defined?(Spring)
   require 'rubygems'
   require 'bundler'
 
-  if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
-    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq }
-    gem 'spring', match[1]
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
     require 'spring/binstub'
   end
 end


### PR DESCRIPTION
We were using version 1.4.1 which contained a bug that would prevent proper error reporting when an initializer or auto-loaded gem resulted in an LoadError being raised and uncaught.

@kariabancroft It looks like we just hit a bit of bad luck. You started this project on Nov 12th, 2015 and the fix for this bug (in version 1.4.2) was release on the 16th.