### PR TITLE
Upgrade omniauth gem to 1.8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'httparty'
 gem 'bootstrap-sass', '~> 3.3.6'
 gem 'font-awesome-sass', '~> 4.5.0'
 
-gem "omniauth", "~> 1.3.2"
+gem "omniauth", "~> 1.8.1"
 gem "omniauth-github"
 
 # Authorization framework

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,9 +120,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.3.2)
-      hashie (>= 1.2, < 4)
-      rack (>= 1.0, < 3)
+    omniauth (1.8.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
     omniauth-github (1.1.2)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.1)
@@ -241,7 +241,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   jquery-turbolinks
-  omniauth (~> 1.3.2)
+  omniauth (~> 1.8.1)
   omniauth-github
   pg
   pry-byebug


### PR DESCRIPTION
Originally I upgraded to 1.3.2 because GitHub informed us of a security
vulnerability with our existing version (1.3.1).

However, that upgrade also resulted in upgrading the hashie gem's
version which further resulted in a warning message upon deployment
because of changes in the hashie gem.

Upgrading to a more recent version of omniauth is apparently the fix, so
this is upgrading to the most recent stable version.